### PR TITLE
minor fixes for some use cases

### DIFF
--- a/cyanure/data_processing.py
+++ b/cyanure/data_processing.py
@@ -97,8 +97,8 @@ def check_labels(labels, estimator):
             label_encoder.fit(labels)
             labels = label_encoder.transform(labels)
     else:
-        if type(labels[0]) not in (np.float32, np.float64):
-            logger.info("The labels have been converted in float64")
+        if labels.dtype not in (np.float32, np.float64):
+            logger.info("The labels have been converted to float64")
             labels = labels.astype('float64')
 
     if False in np.isfinite(labels):
@@ -254,7 +254,7 @@ def check_parameters(estimator):
                              "Penalty term must be positive")
 
     # Verify that it is not the default value
-    if (estimator.penalty is None or estimator.penalty == "none") and estimator.lambda_1 != 0.1:
+    if (estimator.penalty is None or estimator.penalty == "none") and estimator.lambda_1 != 0.0:
         warnings.warn("Setting penalty='none' will ignore the lambda_1")
 
 


### PR DESCRIPTION
In data_processing.py:
1. test `labels.dtype` rather than `labels[0]` to account for multi-task labels
2. remove warning when `penalty == "none"` and `lambda_1 == 0.0` (I think this is what was intended)

In estimators.py:
1. rewording/adding some logging messages
2. fix bug when predicting on a `Regression` model with `fit_intercept == False`
3. minor bug fixes in `fit_large_feature_number` and some modernisation too
4. in `fit_large_feature_number`, move the update of the main estimator from the aux to the end (rather than every step of the loop) and set the `n_features_in_` attribute because that is used to decide if the main estimator has been fitted.

